### PR TITLE
Add support for CentOS 7, add improved structure

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,7 +11,7 @@
 # === Examples
 #
 #  class { 'netcat':
-#    ensure => latest,
+#    package_ensure => latest,
 #  }
 #
 # === Authors
@@ -23,9 +23,14 @@
 # Copyright 2014 Rick Fletcher
 #
 class netcat (
-  $ensure = 'present',
-) {
-  package { 'netcat':
-    ensure => $ensure,
+  $package_ensure = $netcat::params::package_ensure,
+  $package_name   = $netcat::params::package_name,
+) inherits netcat::params {
+
+  package { 'netcat' :
+    allow_virtual => false,
+    ensure        => $package_ensure,
+    name          => $package_name,
   }
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,7 +11,7 @@
 # === Examples
 #
 #  class { 'netcat':
-#    package_ensure => latest,
+#    ensure => latest,
 #  }
 #
 # === Authors

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,14 +23,14 @@
 # Copyright 2014 Rick Fletcher
 #
 class netcat (
-  $package_ensure = $netcat::params::package_ensure,
-  $package_name   = $netcat::params::package_name,
+  $ensure = $netcat::params::package_ensure,
+  $name   = $netcat::params::package_name,
 ) inherits netcat::params {
 
   package { 'netcat' :
     allow_virtual => false,
-    ensure        => $package_ensure,
-    name          => $package_name,
+    ensure        => $ensure,
+    name          => $name,
   }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,32 @@
+# Class: netcat::params
+#
+#   The netcar configuration settings.
+#
+# Parameters:
+#
+# Actions:
+#
+# Requires:
+#
+# Sample Usage:
+#
+class netcat::params {
+
+  $package_ensure = 'present'
+
+  case $::osfamily {
+    'RedHat': {
+      if $::operatingsystemmajrelease >= 7 {
+        $package_name = 'nmap-ncat'
+      } else {
+        $package_name = 'netcat'
+      }
+    }
+
+    # I'm sure the name changes on other systems.  Haven't gotten there yet.  Contribute!
+    default: {
+      $package_name = 'netcat'
+    }
+  }
+
+}


### PR DESCRIPTION
Addes support for CentOS 7 since they apparently don't like the
standard netcat name (jerks).  Instead they use nmap-ncat.  So
fix that and add better structure for parameters as per the puppet
way.

Also cleans up variable names a bit so meaning is clearer and more
standardized.

Have a look and tell me what you think.  First module I have contributed
back to so I don't know all the ways yet.  Any help is appreciated.
